### PR TITLE
Remove some unnecessary lodash dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3048,20 +3048,10 @@
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
     },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
     },
     "lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
   "dependencies": {
     "loader-utils": "^2.0.0",
     "lodash.defaultsdeep": "^4.6.1",
-    "lodash.foreach": "^4.5.0",
     "lodash.get": "^4.4.2",
-    "lodash.isobject": "^3.0.2",
     "lodash.set": "^4.3.2",
     "posthtml-parser": "^0.4.2"
   }

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,7 +1,5 @@
 const get = require('lodash.get');
 const set = require('lodash.set');
-const isObject = require('lodash.isobject');
-const forEach = require('lodash.foreach');
 const parser = require('posthtml-parser');
 
 /**
@@ -15,8 +13,8 @@ module.exports.default = function (content) {
 
     const nodes = parser(content);
 
-    forEach(nodes, (node) => {
-        if (isObject(node) && isCorrectTag(node)) {
+    nodes.forEach((node) => {
+        if (typeof node == 'object' && isCorrectTag(node)) {
             append(output, [node.tag, getType(node)], getContent(node));
         }
     });
@@ -41,7 +39,7 @@ function append(object, path, value) {
  * @returns {string}
  */
 function getContent(node) {
-    return get(node, 'content', []).join(' ');
+    return (node.content || []).join(' ');
 }
 
 /**
@@ -55,7 +53,10 @@ function getType(node) {
         style: 'text/css'
     };
 
-    return get(node, 'attrs.type', tagLoaders[node.tag]);
+    if(typeof node.attrs == 'undefined' || typeof node.attrs.type == 'undefined')
+        return tagLoaders[node.tag];
+
+    return node.attrs.type;
 }
 
 /**


### PR DESCRIPTION
Removes `lodash.foreach` and `lodash.isobject` as they are not needed. Would have liked to also remove `lodash.get` and `lodash.set`, there's only one place left in the code where those are used.